### PR TITLE
Add "say" option for raids as well

### DIFF
--- a/TankWarningsClassic.lua
+++ b/TankWarningsClassic.lua
@@ -97,6 +97,11 @@ function TankWarningsClassic_LoadRaidOptions()
 	info.value = "Message"
 	info.func = TankWarningsClassic_RaidOptionSelected
 	UIDropDownMenu_AddButton(info)
+	info = UIDropDownMenu_CreateInfo()
+	info.text = "Say"
+	info.value = "Say"
+	info.func = TankWarningsClassic_RaidOptionSelected
+	UIDropDownMenu_AddButton(info)
 end
 
 ------- Warning options panel -------
@@ -185,6 +190,8 @@ function f:TWC_SendChatMessage(message)
 	if TankWarningsClassicSV.showInRaids == true and IsInRaid() == true then
 		if TankWarningsClassicSV.raidOption == "Warning" then
 			SendChatMessage(message, "RAID_WARNING", "Common")
+		elseif TankWarningsClassicSV.raidOption == "Say" then
+			SendChatMessage(message, "SAY", "Common")
 		else
 			SendChatMessage(message, "RAID", "Common")
 		end


### PR DESCRIPTION
With spell batching delay it's hard to see when you get a taunt resist. A raid warning is too intrusive for the raid, and a raid message is too hard to notice for yourself. To write in "say" however is perfect for me.